### PR TITLE
scripts/calc_passwd.py: fix

### DIFF
--- a/scripts/calc_passwd.py
+++ b/scripts/calc_passwd.py
@@ -29,6 +29,6 @@ if __name__ == "__main__":
         sys.exit(1)
 
     path = sys.argv[1]
-    _, raw_header = header.extract(path)
+    raw_header = header.extract(path)
     header = header.parse(raw_header)
     print(calc_passwd(header['SN']))


### PR DESCRIPTION
Fixes following error:
Traceback (most recent call last):
  File "D:\src\ax3600-files\scripts\calc_passwd.py", line 32, in <module>
    _, raw_header = header.extract(path)
ValueError: too many values to unpack (expected 2)