### PR TITLE
Fix lstrip()

### DIFF
--- a/scripts/crc32.py
+++ b/scripts/crc32.py
@@ -18,7 +18,7 @@ def extract_human_readable(data):
 
 
 def calculate(data):
-    crc32 = hex(zlib.crc32(data[CRC32_LEN:]) & 0xffffffff).lstrip("0x")
+    crc32 = format(zlib.crc32(data[CRC32_LEN:]) & 0xffffffff, 'x')
     reversed_crc32 = "".join(reversed(textwrap.wrap(crc32.zfill(8), 2)))
     return "0x" + reversed_crc32
 

--- a/scripts/header.py
+++ b/scripts/header.py
@@ -100,7 +100,7 @@ def modify_command(src, dst, country=None, test=False):
     data_without_crc32 = b'\x00' * crc32.CRC32_LEN + new_raw_header + new_zero_data
 
     # calculate new crc32 and update the data with it
-    new_raw_crc32 = bytes.fromhex(crc32.calculate(data_without_crc32).lstrip("0x"))
+    new_raw_crc32 = bytes.fromhex(crc32.calculate(data_without_crc32)[2:])
     new_crc32_data = new_raw_crc32 + data_without_crc32[crc32.CRC32_LEN:]
 
     with open(src, "rb") as f:


### PR DESCRIPTION
The issue is that `.lstrip("0x")` also removes `0` character if it is at the beginning of the CRC32 value.
Something like `1020304` from `0x01020304` instead of `01020304`.
Closes #3